### PR TITLE
No typescript for prod dependencies

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { Connection } from './lib/connection';
 import { Channel } from './lib/channel';
+import { Connection } from './lib/connection';
 export { Connection, Channel };
 export * from 'amqplib';

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
 import { Channel } from './lib/channel';
 import { Connection } from './lib/connection';
 export { Connection, Channel };
-export * from 'amqplib';
+export { Replies, Options, Message, ConfirmChannel, credentials, connect } from 'amqplib';

--- a/index.js
+++ b/index.js
@@ -1,10 +1,8 @@
 "use strict";
-function __export(m) {
-    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
-}
 Object.defineProperty(exports, "__esModule", { value: true });
+const tslib_1 = require("tslib");
 const channel_1 = require("./lib/channel");
 exports.Channel = channel_1.Channel;
 const connection_1 = require("./lib/connection");
 exports.Connection = connection_1.Connection;
-__export(require("amqplib"));
+tslib_1.__exportStar(require("amqplib"), exports);

--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-const tslib_1 = require("tslib");
 const channel_1 = require("./lib/channel");
 exports.Channel = channel_1.Channel;
 const connection_1 = require("./lib/connection");
 exports.Connection = connection_1.Connection;
-tslib_1.__exportStar(require("amqplib"), exports);
+var amqplib_1 = require("amqplib");
+exports.credentials = amqplib_1.credentials;
+exports.connect = amqplib_1.connect;

--- a/index.ts
+++ b/index.ts
@@ -6,4 +6,4 @@ export {
   Channel
 }
 
-export * from 'amqplib'
+export { Replies, Options, Message, ConfirmChannel, credentials, connect } from 'amqplib'

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
   },
   "homepage": "https://github.com/twawszczak/amqplib-as-promised#readme",
   "dependencies": {
-    "@types/amqplib": "^0.5.4",
     "amqplib": "^0.5.2"
   },
   "devDependencies": {
+    "@types/amqplib": "^0.5.4",
     "@types/chai": "^4.1.2",
     "@types/chai-as-promised": "^7.1.0",
     "@types/chai-string": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
   },
   "homepage": "https://github.com/twawszczak/amqplib-as-promised#readme",
   "dependencies": {
-    "amqplib": "^0.5.2",
-    "tslib": "^1.9.0"
+    "amqplib": "^0.5.2"
   },
   "devDependencies": {
     "@types/amqplib": "^0.5.4",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
   "dependencies": {
     "amqplib": "^0.5.2"
   },
+  "peerDependencies": {
+    "@types/amqplib": ">= 0.5.4 < 1"
+  },
   "devDependencies": {
     "@types/amqplib": "^0.5.4",
     "@types/chai": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   },
   "homepage": "https://github.com/twawszczak/amqplib-as-promised#readme",
   "dependencies": {
-    "amqplib": "^0.5.2"
+    "amqplib": "^0.5.2",
+    "tslib": "^1.9.0"
   },
   "devDependencies": {
     "@types/amqplib": "^0.5.4",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "noUnusedParameters": true,
     "esModuleInterop": true,
     "declaration": true,
+    "importHelpers": true,
     "typeRoots": [
       "node_modules/@types"
     ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
     "noUnusedParameters": true,
     "esModuleInterop": true,
     "declaration": true,
-    "importHelpers": true,
     "typeRoots": [
       "node_modules/@types"
     ]


### PR DESCRIPTION
This library is compiled do Javascript so there is no need to use typescript and @types/* as prod dependencies.

Additionally tslib might be used instead inlined functions, so I enabled "importHelpers" option.
