### PR TITLE
Fix events leak

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ services:
 
 matrix:
   include:
-    - node_js: "9"
-
+    - node_js: "node"
+    - node_js: "10"
     - node_js: "8"
 
 install:

--- a/lib/channel.d.ts
+++ b/lib/channel.d.ts
@@ -18,6 +18,7 @@ export declare class Channel extends EventEmitter {
             options?: Options.Consume;
         };
     };
+    protected connectionFinallyClosed: boolean;
     private prefetchCache?;
     private reconnectPromise?;
     private closingByClient;
@@ -46,5 +47,6 @@ export declare class Channel extends EventEmitter {
     protected bindConsumersAfterReconnect(): Promise<void>;
     protected processUnprocessed(): void;
     protected bindNativeChannel(channel: NativeChannel): void;
+    protected bindNativeConnection(): void;
     protected checkPrefetchCache(): Promise<void>;
 }

--- a/lib/channel.js
+++ b/lib/channel.js
@@ -211,10 +211,7 @@ class Channel extends events_1.EventEmitter {
         }
     }
     bindNativeChannel(channel) {
-        channel.once('error', (error) => {
-            this.error = error;
-        });
-        channel.once('close', async () => {
+        const onClose = async () => {
             try {
                 if (!this.closingByClient) {
                     this.reconnectPromise = this.reconnect(this.error);
@@ -224,7 +221,12 @@ class Channel extends events_1.EventEmitter {
             catch (e) {
                 this.emit('error', new Error('Cannot reconnect amqp channel with message: ' + e.message));
             }
-        });
+        };
+        const onError = (err) => {
+            this.error = err;
+        };
+        channel.once('close', onClose);
+        channel.once('error', onError);
         this.channel = channel;
     }
     bindNativeConnection() {

--- a/lib/channel.js
+++ b/lib/channel.js
@@ -8,8 +8,10 @@ class Channel extends events_1.EventEmitter {
         this.processing = false;
         this.suspended = [];
         this.consumerHandlers = {};
+        this.connectionFinallyClosed = false;
         this.closingByClient = false;
         this.bindNativeChannel(channel);
+        this.bindNativeConnection();
     }
     async consume(queueName, handler, options) {
         return this.nativeOperation(async (channel) => {
@@ -183,6 +185,9 @@ class Channel extends events_1.EventEmitter {
         });
     }
     async reconnect(reason) {
+        if (this.connectionFinallyClosed) {
+            return;
+        }
         this.emit('reconnect', reason);
         const nativeChannel = await this.connection.createChannel();
         this.bindNativeChannel(nativeChannel);
@@ -221,6 +226,9 @@ class Channel extends events_1.EventEmitter {
             }
         });
         this.channel = channel;
+    }
+    bindNativeConnection() {
+        this.connection.once('close', () => this.connectionFinallyClosed = true);
     }
     async checkPrefetchCache() {
         if (this.channel && this.prefetchCache) {

--- a/lib/channel.ts
+++ b/lib/channel.ts
@@ -257,11 +257,7 @@ export class Channel extends EventEmitter {
   }
 
   protected bindNativeChannel (channel: NativeChannel): void {
-    channel.once('error', (error) => {
-      this.error = error
-    })
-
-    channel.once('close', async () => {
+    const onClose = async () => {
       try {
         if (!this.closingByClient) {
           this.reconnectPromise = this.reconnect(this.error)
@@ -270,7 +266,14 @@ export class Channel extends EventEmitter {
       } catch (e) {
         this.emit('error', new Error('Cannot reconnect amqp channel with message: ' + e.message))
       }
-    })
+    }
+
+    const onError = (err: Error) => {
+      this.error = err
+    }
+
+    channel.once('close', onClose)
+    channel.once('error', onError)
 
     this.channel = channel
   }

--- a/lib/connection.d.ts
+++ b/lib/connection.d.ts
@@ -4,7 +4,7 @@ import { EventEmitter } from 'events';
 import { Channel } from './channel';
 export declare class Connection extends EventEmitter {
     protected url: string;
-    protected options: amqplib.Options.Connect | undefined;
+    protected options?: amqplib.Options.Connect | undefined;
     protected connection?: amqplib.Connection;
     constructor(url: string, options?: amqplib.Options.Connect | undefined);
     init(): Promise<void>;

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -18,6 +18,7 @@ class Connection extends events_1.EventEmitter {
             this.emit('close');
             delete this.connection;
         });
+        this.connection.on('error', (e) => this.emit('error', e));
     }
     async createChannel() {
         if (!this.connection) {

--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -18,6 +18,8 @@ export class Connection extends EventEmitter {
 
       delete this.connection
     })
+
+    this.connection.on('error', (e) => this.emit('error', e))
   }
 
   async createChannel (): Promise<Channel> {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amqplib-as-promised",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "description": "Amqlib wrapper for support publishing new messages as promised",
   "repository": {
     "type": "git",
@@ -15,28 +15,28 @@
   },
   "homepage": "https://github.com/twawszczak/amqplib-as-promised#readme",
   "dependencies": {
-    "amqplib": "^0.5.2"
+    "amqplib": "^0.5.3"
   },
   "peerDependencies": {
     "@types/amqplib": ">= 0.5.4 < 1"
   },
   "devDependencies": {
-    "@types/amqplib": "^0.5.4",
-    "@types/chai": "^4.1.2",
+    "@types/amqplib": "^0.5.9",
+    "@types/chai": "^4.1.7",
     "@types/chai-as-promised": "^7.1.0",
-    "@types/chai-string": "^1.4.0",
-    "@types/chance": "^1.0.0",
-    "@types/mocha": "^2.2.48",
-    "chai": "^4.1.2",
-    "chai-as-promised": "^7.0.0",
-    "chai-string": "^1.4.0",
-    "chance": "^1.0.12",
-    "mocha": "^5.0.1",
-    "ts-mocha": "^1.1.0",
-    "ts-node": "^5.0.1",
-    "tslint": "^5.9.1",
-    "tslint-config-standard": "^7.0.0",
-    "typescript": "^2.7.2"
+    "@types/chai-string": "^1.4.1",
+    "@types/chance": "^1.0.1",
+    "@types/mocha": "^5.2.5",
+    "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
+    "chai-string": "^1.5.0",
+    "chance": "^1.0.18",
+    "mocha": "^5.2.0",
+    "ts-mocha": "^2.0.0",
+    "ts-node": "^7.0.1",
+    "tslint": "^5.12.0",
+    "tslint-config-standard": "^8.0.1",
+    "typescript": "^3.2.2"
   },
   "scripts": {
     "build": "tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amqplib-as-promised",
-  "version": "3.13.0",
+  "version": "3.14.0",
   "description": "Amqlib wrapper for support publishing new messages as promised",
   "repository": {
     "type": "git",

--- a/test/api/handling-close-in-meantime.ts
+++ b/test/api/handling-close-in-meantime.ts
@@ -38,7 +38,7 @@ const fakeMessage: Message = {
     redelivered: false,
     exchange: '',
     routingKey: '',
-    messageCount: '123'
+    messageCount: 123
   }
 }
 


### PR DESCRIPTION
Without this patch I see a message like this:

```
(node:46858) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 close listeners added. Use emitter.setMaxListeners() to increase limit
```

The library should clean up its listeners on `close`.
