### PR TITLE
Fix native ConfirmChannel being exported instead of the wrapped (promise-based) one

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,13 @@
 import { Channel } from './channel'
+import { ConfirmChannel } from './confirm-channel'
 import { Connection } from './connection'
 
-export { Connection, Channel }
+export { Connection, ConfirmChannel, Channel }
 
 export {
   Replies,
   Options,
   Message,
-  ConfirmChannel,
   credentials,
   connect,
   MessageProperties,


### PR DESCRIPTION
Resolves #6 

BREAKING CHANGE: ConfirmChannel exported from amqplib-as-promised/lib will no longer be of amqplib native ConfirmChannel type