### PR TITLE
Updating amqplib dependency to latest version (0.8.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ returning error as a Promise `reject` response.
 
 ## Requirements
 
-This module requires Node >= 8.
+This module requires Node >= 10.
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "clean:coverage": "shx rm -rf coverage .nyc_output",
     "lint": "npm run compile && tsc --pretty -p test && tslint -t stylish -p . && tslint -t stylish -p test && markdownlint \"*.md\"",
     "postpublish": "node -e \"require(\\\"changelog-parser\\\")(\\\"CHANGELOG.md\\\").then(ch => console.log(ch.versions.filter(v => v.version === \\\"$npm_package_version\\\").map(v => \\\"v$npm_package_version\\n\\n\\\" + v.body).concat(\\\"Release v$npm_package_version\\\")[0]))\" | xargs -0 git tag v$npm_package_version -a -m && git push --tags",
-    "prepack": "npm run compile",
+    "prepare": "npm run compile",
     "prepublishOnly": "npm run test",
     "pretest": "npm run lint",
     "test": "npm run test:spec",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "clean:coverage": "shx rm -rf coverage .nyc_output",
     "lint": "npm run compile && tsc --pretty -p test && tslint -t stylish -p . && tslint -t stylish -p test && markdownlint \"*.md\"",
     "postpublish": "node -e \"require(\\\"changelog-parser\\\")(\\\"CHANGELOG.md\\\").then(ch => console.log(ch.versions.filter(v => v.version === \\\"$npm_package_version\\\").map(v => \\\"v$npm_package_version\\n\\n\\\" + v.body).concat(\\\"Release v$npm_package_version\\\")[0]))\" | xargs -0 git tag v$npm_package_version -a -m && git push --tags",
-    "prepare": "npm run compile",
+    "prepack": "npm run compile",
     "prepublishOnly": "npm run test",
     "pretest": "npm run lint",
     "test": "npm run test:spec",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amqplib-as-promised",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Amqlib wrapper for support publishing new messages as promised",
   "repository": {
     "type": "git",
@@ -14,12 +14,15 @@
     "url": "https://github.com/twawszczak/amqplib-as-promised/issues"
   },
   "homepage": "https://github.com/twawszczak/amqplib-as-promised#readme",
+  "engines": {
+    "node": ">=10"
+  },
   "dependencies": {
-    "amqplib": "^0.5.5",
+    "amqplib": "^0.8.0",
     "tslib": "^1.10.0"
   },
   "devDependencies": {
-    "@types/amqplib": "^0.5.13",
+    "@types/amqplib": "^0.8.2",
     "@types/chai": "^4.2.6",
     "@types/chai-as-promised": "^7.1.2",
     "@types/chai-string": "^1.4.2",


### PR DESCRIPTION
Resolves #5 

- [x] Updating amqplib dependency to latest 0.8.0 version
- [x] Changing package version to 4.1.0
- [x] Required node version is now >= 10, versions < 10 are dropped by mtaqlib (https://github.com/amqp-node/amqplib/blob/main/CHANGELOG.md) 